### PR TITLE
The cache itself is now included to the callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ You can register your own function which will be invoked after an element is sto
 ```elixir
 cache = ConCache.start_link(callback: fn(data) -> ... end)
     
-ConCache.put(cache, key, value)         # fun will be called with {:update, key, value}
-ConCache.delete(cache, key)             # fun will be called with {:delete, key}
+ConCache.put(cache, key, value)         # fun will be called with {:update, cache, key, value}
+ConCache.delete(cache, key)             # fun will be called with {:delete, cache, key}
 ```
 
 The delete callback is invoked before the item is deleted, so you still have the chance to fetch the value from the cache and do something with it.

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -189,7 +189,7 @@ defrecord ConCache, [
   def dirty_put(ConCache[ets: ets] = cache, key, ConCacheItem[ttl: ttl, value: value]) do
     set_ttl(cache, key, ttl)
     :ets.insert(ets, {key, value})
-    invoke_callback(cache, {:update, key, value})
+    invoke_callback(cache, {:update, cache, key, value})
     :ok
   end
 
@@ -255,7 +255,7 @@ defrecord ConCache, [
   
   defp do_delete(ConCache[ets: ets] = cache, key) do
     try do
-      invoke_callback(cache, {:delete, key})
+      invoke_callback(cache, {:delete, cache, key})
     after
       :ets.delete(ets, key)
     end

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -91,16 +91,16 @@ defmodule ConCacheTest do
     cache = ConCache.start_link(callback: fn(data) -> self <- data end)
     
     ConCache.put(cache, :a, 1)
-    assert_receive {:update, :a, 1}
+    assert_receive {:update, cache, :a, 1}
 
     ConCache.update(cache, :a, fn(_) -> 2 end)
-    assert_receive {:update, :a, 2}
+    assert_receive {:update, cache, :a, 2}
 
     ConCache.update_existing(cache, :a, fn(_) -> 3 end)
-    assert_receive {:update, :a, 3}
+    assert_receive {:update, cache, :a, 3}
 
     ConCache.delete(cache, :a)
-    assert_receive {:delete, :a}
+    assert_receive {:delete, _cache, :a}
   end
 
   test "ttl" do


### PR DESCRIPTION
On updates the callback will be called with {:update, cache, key, value}
On deletes the callback is called with {:delete, cache, key}

This makes it easier to act on the item before deletion for example.
