### PR TITLE
add ConCache.select

### DIFF
--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -143,6 +143,20 @@ defmodule ConCache do
   def get(cache_id, key), do: Operations.get(Owner.cache(cache_id), key)
 
   @doc """
+  Searches for items in the cache.
+
+  For more information on MatchSpecs, look into :ets.select/2.
+  ConCache keeps tuples of {key, value} in the table.
+  TTL can only be updated if the MatchFunctions Result is the object itself: [:"$_"].
+
+  A select is always "dirty", meaning it doesn't block while someone is updating
+  the items under the same key. A select doesn't expire TTL of the items, unless
+  `touch_on_read` option is set while starting the cache.
+  """
+  @spec select(t, key) :: [term]
+  def select(cache_id, match_specs), do: Operations.select(Owner.cache(cache_id), match_specs)
+
+  @doc """
   Stores the item into the cache.
   """
   @spec put(t, key, store_value) :: :ok

--- a/lib/con_cache/operations.ex
+++ b/lib/con_cache/operations.ex
@@ -26,6 +26,19 @@ defmodule ConCache.Operations do
     end
   end
 
+  def select(%ConCache{ets: ets} = cache, match_specs) do
+    case :ets.select(ets, match_specs) do
+      [] -> nil
+      results ->
+        results |>
+          Enum.map(fn({key, value}) ->
+                       read_touch(cache, key)
+                       {key, value}
+                     (res) -> res # accept other Results then [:"$_"] but don't update ttl
+          end)
+    end
+  end
+
   defp read_touch(%ConCache{touch_on_read: false}, _), do: :ok
   defp read_touch(%ConCache{touch_on_read: true} = cache, key) do
     touch(cache, key)

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -254,4 +254,13 @@ defmodule ConCacheTest do
       end)
     end
   end
+
+  test "select" do
+    with_cache(fn(cache) ->
+      ConCache.put(cache, :a, 1)
+      ConCache.put(cache, :b, 2)
+      assert ConCache.select(cache, [{{:_, :"$1"}, [{:>, :"$1", 1}], [:"$_"]}]) == [{:b, 2}]
+      assert ConCache.select(cache, [{{:_, :"$1"}, [{:>, :"$1", 1}], [:"$1"]}]) == [2]
+    end)
+  end
 end


### PR DESCRIPTION
* allows to execute ets match specs
* TTL can only be updated when the MatchSpec Returns [:"$_"]