### PR TITLE
add :no_update option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ ConCache.update(:my_cache, key, fn(old_value) ->
 end)
 ```
 
+And you can update an item without resetting the item's ttl:
+
+```elixir
+ConCache.put(:my_cache, key, %ConCache.Item{value: value, ttl: :no_update})
+
+ConCache.update(:my_cache, key, fn(old_value) ->
+  %ConCache.Item{value: new_value, ttl: :no_update}
+end)
+```
+
 If you use ttl value of 0 the item never expires.
 In addition, unless you set `ttl_check` interval, the ttl check process will not be started, and items will never expire.
 

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -3,7 +3,7 @@ defmodule ConCache.Item do
   This struct can be used in place of naked values to set per-item TTL values.
   """
   defstruct value: nil, ttl: 0
-  @type t :: %ConCache.Item{value: ConCache.value, ttl: pos_integer}
+  @type t :: %ConCache.Item{value: ConCache.value, ttl: pos_integer | :renew | :no_update}
 end
 
 defmodule ConCache do

--- a/lib/con_cache/operations.ex
+++ b/lib/con_cache/operations.ex
@@ -99,6 +99,7 @@ defmodule ConCache.Operations do
     dirty_put(cache, key, %ConCache.Item{value: value, ttl: ttl})
   end
 
+  defp set_ttl(_, _, :no_update), do: :ok
   defp set_ttl(%ConCache{ttl_manager: nil}, _, _), do: :ok
   defp set_ttl(%ConCache{ttl_manager: ttl_manager}, key, ttl) do
     ConCache.Owner.set_ttl(ttl_manager, key, ttl)

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -175,6 +175,20 @@ defmodule ConCacheTest do
     end
   end)
 
+  test "no_update" do
+    with_cache(
+      [ttl_check: 10, ttl: 50],
+      fn(cache) ->
+        ConCache.put(cache, :a, 1)
+        :timer.sleep(40)
+        ConCache.put(cache, :a, %ConCache.Item{value: 2, ttl: :no_update})
+        ConCache.update(cache, :a, fn(old) -> {:ok, %ConCache.Item{value: 3, ttl: :no_update}} end)
+        assert ConCache.get(cache, :a) == 3
+        :timer.sleep(40)
+        assert ConCache.get(cache, :a) == nil
+      end)
+  end
+
   defp test_renew_ttl(cache, fun) do
     ConCache.put(cache, :a, 1)
     :timer.sleep(50)


### PR DESCRIPTION
In %ConCache.Item{ttl: :no_update} can be set to omit touching the entries ttl even when updating/putting.