### PR TITLE
Remove redundant case clause

### DIFF
--- a/lib/con_cache/operations.ex
+++ b/lib/con_cache/operations.ex
@@ -38,8 +38,6 @@ defmodule ConCache.Operations do
             |> Enum.map(fn {^key, value} -> value end)
           read_touch(cache, key)
           {:ok, values}
-
-      _ -> :error
     end
   end
 


### PR DESCRIPTION
`:ets.lookup/2` always returns `[Object]` which is covered with the previous case clauses.