### PR TITLE
Support Elixir 1.5.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ConCache.Mixfile do
     [
       app: :con_cache,
       version: @version,
-      elixir: "~> 1.4.0",
+      elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),


### PR DESCRIPTION
Fixes warning: the dependency :con_cache requires Elixir "~> 1.4.0" but you are running on v1.5.0