### PR TITLE
Make ttl options log an error when missing/invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,22 +113,22 @@ The delete callback is invoked before the item is deleted, so you still have the
 ```elixir
 supervisor(ConCache, [
   [
-    ttl_check: :timer.seconds(1),
-    ttl: :timer.seconds(5)
+    ttl_check_interval: :timer.seconds(1),
+    global_ttl: :timer.seconds(5)
   ],
   [name: :my_cache]
 ])
 ```
 
-This example sets up item expiry check every second. The default expiry for all cache items is 5 seconds. Since ttl_check interval is 1 second, the item lifetime might be at most 6 seconds.
+This example sets up item expiry check every second, and sets the global expiry for all cache items to 5 seconds. Since ttl_check_interval is 1 second, the item lifetime might be at most 6 seconds.
 
-However, the item lifetime is renewed on every modification. Reads don't extend ttl, but this can be changed when starting cache:
+However, the item lifetime is renewed on every modification. Reads don't extend global_ttl, but this can be changed when starting cache:
 
 ```elixir
 supervisor(ConCache, [
   [
-    ttl_check: :timer.seconds(1),
-    ttl: :timer.seconds(5),
+    ttl_check_interval: :timer.seconds(1),
+    global_ttl: :timer.seconds(5),
     touch_on_read: true
   ],
   [name: :my_cache]
@@ -162,9 +162,8 @@ end)
 ```
 
 If you use ttl value of 0 the item never expires.
-In addition, unless you set `ttl_check` interval, the ttl check process will not be started, and items will never expire.
 
-TTL check __is not__ based on brute force table scan, and should work reasonably fast assuming the check interval is not too small. I generally recommend `ttl_check` to be at least 1 second, possibly more, depending on the cache size and desired ttl.
+TTL check __is not__ based on brute force table scan, and should work reasonably fast assuming the check interval is not too small. I generally recommend `ttl_check_interval` to be at least 1 second, possibly more, depending on the cache size and desired ttl.
 
 ## Supervision
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ If you use ttl value of 0 the item never expires.
 
 TTL check __is not__ based on brute force table scan, and should work reasonably fast assuming the check interval is not too small. I generally recommend `ttl_check_interval` to be at least 1 second, possibly more, depending on the cache size and desired ttl.
 
+If needed, you may also pass false to `ttl_check_interval`. This effectively stops `con_cache` from checking the ttl of your items:
+
+```elixir
+supervisor(ConCache, [
+  [
+    ttl_check_interval: false
+  ],
+  [name: :my_cache]
+])
+```
+
 ## Supervision
 
 A call to `ConCache.start_link` (or `start`) creates the so called _cache owner process_. This is the process that is the owner of the underlying ETS table and also the process where TTL checks are performed. No other operation (such as get or put) runs in this process.

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -118,7 +118,7 @@ defmodule ConCache do
   """
   @spec start_link(options, [name: GenServer.name]) :: Supervisor.on_start
   def start_link(options, sup_opts \\ []) do
-    with :ok <- validate_ttl(options[:ttl], Keyword.fetch(options, :ttl_check)) do
+    with :ok <- validate_ttl(options[:ttl], options[:ttl_check]) do
       Supervisor.start_link(
         [
           Supervisor.Spec.supervisor(ConCache.LockSupervisor, [System.schedulers_online()]),
@@ -131,12 +131,12 @@ defmodule ConCache do
 
   defp validate_ttl(ttl, ttl_check) do
     case {ttl, ttl_check} do
-      {false, {:ok, _}}   -> {:error, "ConCache ttl is false and ttl_check is set. Either remove your ttl_check (to remove ttl) or set your ttl to a time"}
-      {nil,   :error}     -> {:error, "ConCache ttl must be set or explicitly set as false (no expiry)"}
-      {nil,   {:ok, _}}   -> {:error, "ConCache ttl must be supplied"}
-      {false, _ttl_check} -> :ok # no expiry
-      {_ttl,  :error}     -> {:error, "ConCache ttl_check must be supplied"}
-      {_ttl,  _ttl_check} -> :ok # ttl expiry
+      {nil,   :error}    -> {:error, "ConCache ttl must be set or explicitly set as false (no expiry)"}
+      {false, nil}       -> :ok # no expiry
+      {false, _ttl_check}-> {:error, "ConCache ttl is false and ttl_check is set. Either remove your ttl_check (to remove ttl) or set your ttl to a time"}
+      {nil,   _ttl_check}-> {:error, "ConCache ttl must be supplied"}
+      {_ttl,  nil}       -> {:error, "ConCache ttl_check must be supplied"}
+      {_ttl,  _ttl_check}-> :ok # ttl expiry
     end
   end
 

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -79,7 +79,7 @@ defmodule ConCache do
   Starts the server and creates an ETS table.
 
   Options:
-    - `{:ttl_check_interval, time_ms}` - A check interval for TTL expiry.
+    - `{:ttl_check_interval, time_ms | false}` - A check interval for TTL expiry.
       Provide a positive integer for TTL to work, or pass `false` to disable ttl checks.
       See below for more details on inner workings of TTL.
     - `{:global_ttl, time_ms}` - The default time after which an item expires.

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -118,7 +118,7 @@ defmodule ConCache do
   """
   @spec start_link(options, [name: GenServer.name]) :: Supervisor.on_start
   def start_link(options, sup_opts \\ []) do
-    with :ok <- validate_ttl(options[:ttl], options[:ttl_check]) do
+    with :ok <- validate_ttl(options[:ttl_check], options[:ttl]) do
       Supervisor.start_link(
         [
           Supervisor.Spec.supervisor(ConCache.LockSupervisor, [System.schedulers_online()]),
@@ -129,12 +129,11 @@ defmodule ConCache do
     end
   end
 
-  defp validate_ttl(nil, :error), do: {:error, "ConCache ttl must be set or explicitly set as false (no expiry)"}
   defp validate_ttl(false, nil), do: :ok
-  defp validate_ttl(false, _ttl_check), do: {:error, "ConCache ttl is false and ttl_check is set. Either remove your ttl_check (to remove ttl) or set your ttl to a time"}
-  defp validate_ttl(nil, _ttl_check), do: {:error, "ConCache ttl must be supplied"}
-  defp validate_ttl(_ttl, nil), do: {:error, "ConCache ttl_check must be supplied"}
-  defp validate_ttl(_ttl, _ttl_check), do: :ok
+  defp validate_ttl(false, _ttl), do: {:error, "ConCache ttl_check is false and ttl is set. Either remove your ttl (to remove global ttl) or set ttl_check to a time"}
+  defp validate_ttl(nil, _ttl), do: {:error, "ConCache ttl_check must be supplied"}
+  defp validate_ttl(_ttl_check, nil), do: {:error, "ConCache ttl must be supplied"}
+  defp validate_ttl(ttl_check, ttl), do: :ok
 
   @doc """
   Returns the ets table managed by the cache.

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -129,16 +129,12 @@ defmodule ConCache do
     end
   end
 
-  defp validate_ttl(ttl, ttl_check) do
-    case {ttl, ttl_check} do
-      {nil,   :error}    -> {:error, "ConCache ttl must be set or explicitly set as false (no expiry)"}
-      {false, nil}       -> :ok # no expiry
-      {false, _ttl_check}-> {:error, "ConCache ttl is false and ttl_check is set. Either remove your ttl_check (to remove ttl) or set your ttl to a time"}
-      {nil,   _ttl_check}-> {:error, "ConCache ttl must be supplied"}
-      {_ttl,  nil}       -> {:error, "ConCache ttl_check must be supplied"}
-      {_ttl,  _ttl_check}-> :ok # ttl expiry
-    end
-  end
+  defp validate_ttl(nil, :error), do: {:error, "ConCache ttl must be set or explicitly set as false (no expiry)"}
+  defp validate_ttl(false, nil), do: :ok
+  defp validate_ttl(false, _ttl_check), do: {:error, "ConCache ttl is false and ttl_check is set. Either remove your ttl_check (to remove ttl) or set your ttl to a time"}
+  defp validate_ttl(nil, _ttl_check), do: {:error, "ConCache ttl must be supplied"}
+  defp validate_ttl(_ttl, nil), do: {:error, "ConCache ttl_check must be supplied"}
+  defp validate_ttl(_ttl, _ttl_check), do: :ok
 
   @doc """
   Returns the ets table managed by the cache.

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -131,9 +131,9 @@ defmodule ConCache do
   end
 
   defp validate_ttl(false, nil), do: :ok
-  defp validate_ttl(false, _global_ttl), do: {:error, "ConCache ttl_check_interval is false and global_ttl is set. Either remove your global_ttl or set ttl_check_interval to a time"}
-  defp validate_ttl(nil, _global_ttl), do: {:error, "ConCache ttl_check_interval must be supplied"}
-  defp validate_ttl(_ttl_check_interval, nil), do: {:error, "ConCache global_ttl must be supplied"}
+  defp validate_ttl(false, _global_ttl), do: raise ArgumentError, "ConCache ttl_check_interval is false and global_ttl is set. Either remove your global_ttl or set ttl_check_interval to a time"
+  defp validate_ttl(nil, _global_ttl), do: raise ArgumentError, "ConCache ttl_check_interval must be supplied"
+  defp validate_ttl(_ttl_check_interval, nil), do: raise ArgumentError, "ConCache global_ttl must be supplied"
   defp validate_ttl(_ttl_check_interval, _global_ttl), do: :ok
 
   @doc """

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -66,7 +66,7 @@ defmodule ConCache do
     {:acquire_lock_timeout, pos_integer} |
     {:callback, callback_fun} |
     {:touch_on_read, boolean} |
-    {:ttl_check_interval, non_neg_integer} |
+    {:ttl_check_interval, non_neg_integer | false} |
     {:time_size, pos_integer} |
     {:ets_options, [ets_option]}
   ]
@@ -79,8 +79,8 @@ defmodule ConCache do
   Starts the server and creates an ETS table.
 
   Options:
-    - `{:ttl_check_interval, time_ms}` - A check interval for TTL expiry. This value is
-      by default `nil` and you need to provide a positive integer for TTL to work.
+    - `{:ttl_check_interval, time_ms}` - A check interval for TTL expiry.
+      Provide a positive integer for TTL to work, or pass `false` to disable ttl checks.
       See below for more details on inner workings of TTL.
     - `{:global_ttl, time_ms}` - The default time after which an item expires.
       When an item expires, it is removed from the cache. Updating the item

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -10,27 +10,17 @@ defmodule ConCacheTest do
   end
 
   test "no error when ttl options are valid" do
-    assert capture_log([level: :error], fn ->
-      ConCache.start_link([ttl: false])
-     end) =~ ""
-
-    assert capture_log([level: :error], fn ->
-      ConCache.start_link([ttl: :timer.seconds(1), ttl_check: :timer.seconds(1)])
-     end) =~ ""
+    assert {:ok, _} = ConCache.start_link([ttl: false])
+    assert {:ok, _} = ConCache.start_link([ttl: :timer.seconds(1), ttl_check: :timer.seconds(1)])
   end
 
   test "error when ttl options are invalid" do
-    assert capture_log([level: :error], fn ->
-      ConCache.start_link([ttl: :timer.seconds(1)])
-    end) =~ "ConCache ttl_check must be supplied"
-
-    assert capture_log([level: :error], fn ->
-      ConCache.start_link([ttl_check: :timer.seconds(1)])
-    end) =~ "ConCache ttl must be supplied"
-
-    assert capture_log([level: :error], fn ->
-      ConCache.start_link([ttl: false, ttl_check: :timer.seconds(1)])
-    end) =~ "ConCache ttl is false and ttl_check is set. Either remove your ttl_check (to remove ttl) or set your ttl to a time"
+    assert {:error, "ConCache ttl_check must be supplied"} = ConCache.start_link([ttl: :timer.seconds(1)])
+    assert {:error, "ConCache ttl must be supplied"} = ConCache.start_link([ttl_check: :timer.seconds(1)])
+    assert {
+      :error,
+      "ConCache ttl is false and ttl_check is set. Either remove your ttl_check (to remove ttl) or set your ttl to a time"
+    } = ConCache.start_link([ttl: false, ttl_check: :timer.seconds(1)])
   end
 
   test "put" do

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -7,18 +7,18 @@ defmodule ConCacheTest do
   end
 
   test "no error when ttl options are valid" do
-    assert {:ok, _} = ConCache.start_link([ttl_check: false])
-    assert {:ok, _} = ConCache.start_link([ttl_check: :timer.seconds(1), ttl: 0])
+    assert {:ok, _} = ConCache.start_link([ttl_check_interval: false])
+    assert {:ok, _} = ConCache.start_link([ttl_check_interval: :timer.seconds(1), global_ttl: 0])
   end
 
   test "error when ttl options are invalid" do
-    assert {:error, "ConCache ttl_check must be supplied"} = ConCache.start_link([])
-    assert {:error, "ConCache ttl_check must be supplied"} = ConCache.start_link([ttl: :timer.seconds(1)])
-    assert {:error, "ConCache ttl must be supplied"} = ConCache.start_link([ttl_check: :timer.seconds(1)])
+    assert {:error, "ConCache ttl_check_interval must be supplied"} = ConCache.start_link([])
+    assert {:error, "ConCache ttl_check_interval must be supplied"} = ConCache.start_link([global_ttl: :timer.seconds(1)])
+    assert {:error, "ConCache global_ttl must be supplied"} = ConCache.start_link([ttl_check_interval: :timer.seconds(1)])
     assert {
       :error,
-      "ConCache ttl_check is false and ttl is set. Either remove your ttl (to remove global ttl) or set ttl_check to a time"
-    } = ConCache.start_link([ttl: :timer.seconds(1), ttl_check: false])
+      "ConCache ttl_check_interval is false and global_ttl is set. Either remove your global_ttl or set ttl_check_interval to a time"
+    } = ConCache.start_link([global_ttl: :timer.seconds(1), ttl_check_interval: false])
   end
 
   test "put" do
@@ -238,7 +238,7 @@ defmodule ConCacheTest do
 
   Enum.each([1, 2, 4, 8], fn(time_size) ->
     test "ttl #{time_size}" do
-      {:ok, cache} = ConCache.start_link(ttl_check: 10, ttl: 50, time_size: unquote(time_size))
+      {:ok, cache} = ConCache.start_link(ttl_check_interval: 10, global_ttl: 50, time_size: unquote(time_size))
 
       ConCache.put(cache, :a, 1)
       :timer.sleep(40)
@@ -267,7 +267,7 @@ defmodule ConCacheTest do
   end)
 
   test "no_update" do
-    {:ok, cache} = ConCache.start_link(ttl_check: 10, ttl: 50)
+    {:ok, cache} = ConCache.start_link(ttl_check_interval: 10, global_ttl: 50)
     ConCache.put(cache, :a, 1)
     :timer.sleep(40)
     ConCache.put(cache, :a, %ConCache.Item{value: 2, ttl: :no_update})
@@ -277,8 +277,8 @@ defmodule ConCacheTest do
     assert ConCache.get(cache, :a) == nil
   end
 
-  test "created key with update should have default ttl" do
-    {:ok, cache} = ConCache.start_link(ttl_check: 10, ttl: 10)
+  test "created key with update should have default global_ttl" do
+    {:ok, cache} = ConCache.start_link(ttl_check_interval: 10, global_ttl: 10)
     ConCache.update(cache, :a, fn(_) -> {:ok, 1} end)
     assert ConCache.get(cache, :a) == 1
     :timer.sleep(50)
@@ -297,7 +297,7 @@ defmodule ConCacheTest do
   end
 
   test "touch_on_read" do
-    {:ok, cache} = ConCache.start_link(ttl_check: 10, ttl: 50, touch_on_read: true)
+    {:ok, cache} = ConCache.start_link(ttl_check_interval: 10, global_ttl: 50, touch_on_read: true)
     ConCache.put(cache, :a, 1)
     :timer.sleep(40)
     assert ConCache.get(cache, :a) == 1
@@ -361,6 +361,6 @@ defmodule ConCacheTest do
   end
 
   defp start_cache(opts \\ [], sup_opts \\ []) do
-    ConCache.start_link(Keyword.merge([ttl_check: false], opts), sup_opts)
+    ConCache.start_link(Keyword.merge([ttl_check_interval: false], opts), sup_opts)
   end
 end

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -1,11 +1,8 @@
 defmodule ConCacheTest do
   use ExUnit.Case, async: false
-  import ExUnit.CaptureLog
-
-  @opts [ttl: false]
 
   test "initial" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     assert ConCache.get(cache, :a) == nil
   end
 
@@ -24,27 +21,27 @@ defmodule ConCacheTest do
   end
 
   test "put" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     assert ConCache.put(cache, :a, 1) == :ok
     assert ConCache.get(cache, :a) == 1
   end
 
   test "multiple put on bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:bag])
+    {:ok, cache} = start_cache(ets_options: [:bag])
     ConCache.put(cache, :a, 1)
     ConCache.put(cache, :a, 2)
     assert ConCache.get(cache, :a) == [1,2]
   end
 
   test "multiple put on duplicate_bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:duplicate_bag])
+    {:ok, cache} = start_cache(ets_options: [:duplicate_bag])
     ConCache.put(cache, :a, 1)
     ConCache.put(cache, :a, 1)
     assert ConCache.get(cache, :a) == [1,1]
   end
 
   test "insert_new" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     assert ConCache.insert_new(cache, :b, 2) == :ok
     assert ConCache.get(cache, :b) == 2
     assert ConCache.insert_new(cache, :b, 3) == {:error, :already_exists}
@@ -52,7 +49,7 @@ defmodule ConCacheTest do
   end
 
   test "insert_new after multiple put on bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:bag])
+    {:ok, cache} = start_cache(ets_options: [:bag])
     ConCache.put(cache, :a, 1)
     ConCache.put(cache, :a, 2)
     ConCache.insert_new(cache, :a, 3)
@@ -60,7 +57,7 @@ defmodule ConCacheTest do
   end
 
   test "insert_new after multiple put on duplicate_bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:duplicate_bag])
+    {:ok, cache} = start_cache(ets_options: [:duplicate_bag])
     ConCache.put(cache, :a, 1)
     ConCache.put(cache, :a, 1)
     ConCache.insert_new(cache, :a, 2)
@@ -68,14 +65,14 @@ defmodule ConCacheTest do
   end
 
   test "delete" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     ConCache.put(cache, :a, 1)
     assert ConCache.delete(cache, :a) == :ok
     assert ConCache.get(cache, :a) == nil
   end
 
   test "delete on bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:bag])
+    {:ok, cache} = start_cache(ets_options: [:bag])
     ConCache.put(cache, :a, 1)
     ConCache.put(cache, :a, 2)
     assert ConCache.delete(cache, :a) == :ok
@@ -83,7 +80,7 @@ defmodule ConCacheTest do
   end
 
   test "delete on duplicate_bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:duplicate_bag])
+    {:ok, cache} = start_cache(ets_options: [:duplicate_bag])
     ConCache.put(cache, :a, 1)
     ConCache.put(cache, :a, 1)
     assert ConCache.delete(cache, :a) == :ok
@@ -91,7 +88,7 @@ defmodule ConCacheTest do
   end
 
   test "update" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     ConCache.put(cache, :a, 1)
     assert ConCache.update(cache, :a, &({:ok, &1 + 1})) == :ok
     assert ConCache.get(cache, :a) == 2
@@ -100,7 +97,7 @@ defmodule ConCacheTest do
   end
 
   test "raise when update bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:bag])
+    {:ok, cache} = start_cache(ets_options: [:bag])
     ConCache.put(cache, :a, 1)
     assert_raise(
       ArgumentError,
@@ -110,7 +107,7 @@ defmodule ConCacheTest do
   end
 
   test "raise when update duplicate_bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:duplicate_bag])
+    {:ok, cache} = start_cache(ets_options: [:duplicate_bag])
     ConCache.put(cache, :a, 1)
     assert_raise(
       ArgumentError,
@@ -120,7 +117,7 @@ defmodule ConCacheTest do
   end
 
   test "update_existing" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     assert ConCache.update_existing(cache, :a, &({:ok, &1 + 1})) == {:error, :not_existing}
     ConCache.put(cache, :a, 1)
     assert ConCache.update_existing(cache, :a, &({:ok, &1 + 1})) == :ok
@@ -128,7 +125,7 @@ defmodule ConCacheTest do
   end
 
   test "raise when update_existing bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:bag])
+    {:ok, cache} = start_cache(ets_options: [:bag])
     ConCache.put(cache, :a, 1)
     assert_raise(
       ArgumentError,
@@ -138,7 +135,7 @@ defmodule ConCacheTest do
   end
 
   test "raise when update_existing duplicate_bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:duplicate_bag])
+    {:ok, cache} = start_cache(ets_options: [:duplicate_bag])
     ConCache.put(cache, :a, 1)
     assert_raise(
       ArgumentError,
@@ -148,7 +145,7 @@ defmodule ConCacheTest do
   end
 
   test "invalid update" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     ConCache.put(cache, :a, 1)
     assert_raise(
       RuntimeError,
@@ -158,14 +155,14 @@ defmodule ConCacheTest do
   end
 
   test "get_or_store" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     assert ConCache.get_or_store(cache, :a, fn() -> 1 end) == 1
     assert ConCache.get_or_store(cache, :a, fn() -> 2 end) == 1
     assert ConCache.get_or_store(cache, :b, fn() -> 4 end) == 4
   end
 
   test "raise when get_or_store bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:bag])
+    {:ok, cache} = start_cache(ets_options: [:bag])
     assert_raise(
       ArgumentError,
       ~r/^This function is.*/,
@@ -174,7 +171,7 @@ defmodule ConCacheTest do
   end
 
   test "raise when get_or_store duplicate_bag" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:duplicate_bag])
+    {:ok, cache} = start_cache(ets_options: [:duplicate_bag])
     assert_raise(
       ArgumentError,
       ~r/^This function is.*/,
@@ -183,14 +180,14 @@ defmodule ConCacheTest do
   end
 
   test "size" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     assert ConCache.size(cache) == 0
     ConCache.put(cache, :a, "foo")
     assert ConCache.size(cache) == 1
   end
 
   test "dirty" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     assert ConCache.dirty_put(cache, :a, 1) == :ok
     assert ConCache.get(cache, :a) == 1
 
@@ -216,14 +213,14 @@ defmodule ConCacheTest do
   end
 
   test "ets_options" do
-    {:ok, cache} = ConCache.start_link(with_opts ets_options: [:named_table, name: :test_name])
+    {:ok, cache} = start_cache(ets_options: [:named_table, name: :test_name])
     assert :ets.info(ConCache.ets(cache), :named_table) == true
     assert :ets.info(ConCache.ets(cache), :name) == :test_name
   end
 
   test "callback" do
     me = self()
-    {:ok, cache} = ConCache.start_link(with_opts callback: &send(me, &1))
+    {:ok, cache} = start_cache(callback: &send(me, &1))
 
     ConCache.put(cache, :a, 1)
     assert_receive {:update, ^cache, :a, 1}
@@ -310,7 +307,7 @@ defmodule ConCacheTest do
   end
 
   test "try_isolated" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     spawn(fn() ->
       ConCache.isolated(cache, :a, fn() -> :timer.sleep(100) end)
     end)
@@ -323,7 +320,7 @@ defmodule ConCacheTest do
   end
 
   test "nested" do
-    {:ok, cache} = ConCache.start_link(@opts)
+    {:ok, cache} = start_cache()
     assert ConCache.isolated(cache, :a, fn() ->
       ConCache.isolated(cache, :b, fn() ->
         ConCache.isolated(cache, :c, fn() -> 1 end)
@@ -334,8 +331,8 @@ defmodule ConCacheTest do
   end
 
   test "multiple" do
-    {:ok, cache1} = ConCache.start_link(@opts)
-    {:ok, cache2} = ConCache.start_link(@opts)
+    {:ok, cache1} = start_cache()
+    {:ok, cache2} = start_cache()
     ConCache.put(cache1, :a, 1)
     ConCache.put(cache2, :b, 2)
     assert ConCache.get(cache1, :a) == 1
@@ -351,7 +348,7 @@ defmodule ConCacheTest do
   for name <- [:cache, {:global, :cache}, {:via, :global, :cache2}] do
     test "registration #{inspect name}" do
       name = unquote(Macro.escape(name))
-      {:ok, _} = ConCache.start_link(@opts, name: name)
+      {:ok, _} = start_cache([], name: name)
       ConCache.put(name, :a, 1)
       assert ConCache.get(name, :a) == 1
     end
@@ -362,7 +359,7 @@ defmodule ConCacheTest do
     assert catch_exit(ConCache.put({:global, :non_existing}, :a, 1)) == :noproc
   end
 
-  defp with_opts(keys) do
-    Keyword.merge(@opts, keys)
+  defp start_cache(opts \\ [], sup_opts \\ []) do
+    ConCache.start_link(Keyword.merge([ttl: false], opts), sup_opts)
   end
 end

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -7,17 +7,18 @@ defmodule ConCacheTest do
   end
 
   test "no error when ttl options are valid" do
-    assert {:ok, _} = ConCache.start_link([ttl: false])
-    assert {:ok, _} = ConCache.start_link([ttl: :timer.seconds(1), ttl_check: :timer.seconds(1)])
+    assert {:ok, _} = ConCache.start_link([ttl_check: false])
+    assert {:ok, _} = ConCache.start_link([ttl_check: :timer.seconds(1), ttl: 0])
   end
 
   test "error when ttl options are invalid" do
+    assert {:error, "ConCache ttl_check must be supplied"} = ConCache.start_link([])
     assert {:error, "ConCache ttl_check must be supplied"} = ConCache.start_link([ttl: :timer.seconds(1)])
     assert {:error, "ConCache ttl must be supplied"} = ConCache.start_link([ttl_check: :timer.seconds(1)])
     assert {
       :error,
-      "ConCache ttl is false and ttl_check is set. Either remove your ttl_check (to remove ttl) or set your ttl to a time"
-    } = ConCache.start_link([ttl: false, ttl_check: :timer.seconds(1)])
+      "ConCache ttl_check is false and ttl is set. Either remove your ttl (to remove global ttl) or set ttl_check to a time"
+    } = ConCache.start_link([ttl: :timer.seconds(1), ttl_check: false])
   end
 
   test "put" do
@@ -360,6 +361,6 @@ defmodule ConCacheTest do
   end
 
   defp start_cache(opts \\ [], sup_opts \\ []) do
-    ConCache.start_link(Keyword.merge([ttl: false], opts), sup_opts)
+    ConCache.start_link(Keyword.merge([ttl_check: false], opts), sup_opts)
   end
 end

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -12,13 +12,18 @@ defmodule ConCacheTest do
   end
 
   test "error when ttl options are invalid" do
-    assert {:error, "ConCache ttl_check_interval must be supplied"} = ConCache.start_link([])
-    assert {:error, "ConCache ttl_check_interval must be supplied"} = ConCache.start_link([global_ttl: :timer.seconds(1)])
-    assert {:error, "ConCache global_ttl must be supplied"} = ConCache.start_link([ttl_check_interval: :timer.seconds(1)])
-    assert {
-      :error,
-      "ConCache ttl_check_interval is false and global_ttl is set. Either remove your global_ttl or set ttl_check_interval to a time"
-    } = ConCache.start_link([global_ttl: :timer.seconds(1), ttl_check_interval: false])
+    assert_raise ArgumentError, "ConCache ttl_check_interval must be supplied", fn ->
+      ConCache.start_link([])
+    end
+    assert_raise ArgumentError, "ConCache ttl_check_interval must be supplied", fn ->
+      ConCache.start_link([global_ttl: :timer.seconds(1)])
+    end
+    assert_raise ArgumentError, "ConCache global_ttl must be supplied", fn ->
+      ConCache.start_link([ttl_check_interval: :timer.seconds(1)])
+    end
+    assert_raise ArgumentError, "ConCache ttl_check_interval is false and global_ttl is set. Either remove your global_ttl or set ttl_check_interval to a time", fn ->
+      ConCache.start_link([global_ttl: :timer.seconds(1), ttl_check_interval: false])
+    end
   end
 
   test "put" do


### PR DESCRIPTION
Stab at #41 

Not sure if it's the cleanest way to write it but I think it's good/clear enough. Though perhaps it will be better to raise an argument error rather than just logging one?