### PR TITLE
Highlight different APIs between Readme.md and Hexdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ ConCache (Concurrent Cache) is an ETS based key/value storage with following add
 * TTL support
 * modification callbacks
 
+### The below docs are for the development version, and differ from the Hex.pm docs. 
+### Read the [hexdocs.pm](https://hexdocs.pm/con_cache/) for the live docs
+
 ## Usage in OTP applications
 
 Setup project and app dependency in your `mix.exs`:


### PR DESCRIPTION
Since there hasn't been a new version in a while, the readme, and the hexdocs are now vastly different. Wasn't immediately clear to me that I needed to use the hexdocs.pm documentation since 2 important options (ttl_check, ttl) were renamed to (ttl_check_interval, global_ttl).

This will probably be useful for any users who stumble onto the library.