### PR TITLE
Add ConCache.child_spec/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Typically you want to start the cache from a supervisor:
 Supervisor.start_link(
   [
     ...
-    supervisor(ConCache, [[], [name: :my_cache]])
+    {ConCache, [name: :my_cache]}
     ...
   ],
   ...
@@ -103,7 +103,7 @@ ConCache.dirty_get_or_store(:my_cache, key, fn() -> ... end)
 You can register your own function which will be invoked after an element is stored or deleted:
 
 ```elixir
-supervisor(ConCache, [[callback: fn(data) -> ... end], [name: :my_cache]])
+{ConCache, [name: :my_cache, callback: fn(data) -> ... end]}
 
 ConCache.put(:my_cache, key, value)         # fun will be called with {:update, cache_pid, key, value}
 ConCache.delete(:my_cache, key)             # fun will be called with {:delete, cache_pid, key}
@@ -114,13 +114,11 @@ The delete callback is invoked before the item is deleted, so you still have the
 ### TTL
 
 ```elixir
-supervisor(ConCache, [
-  [
-    ttl_check_interval: :timer.seconds(1),
-    global_ttl: :timer.seconds(5)
-  ],
-  [name: :my_cache]
-])
+{ConCache, [
+  name: :my_cache,
+  ttl_check_interval: :timer.seconds(1),
+  global_ttl: :timer.seconds(5)
+]}
 ```
 
 This example sets up item expiry check every second, and sets the global expiry for all cache items to 5 seconds. Since ttl_check_interval is 1 second, the item lifetime might be at most 6 seconds.
@@ -128,14 +126,12 @@ This example sets up item expiry check every second, and sets the global expiry 
 However, the item lifetime is renewed on every modification. Reads don't extend global_ttl, but this can be changed when starting cache:
 
 ```elixir
-supervisor(ConCache, [
-  [
-    ttl_check_interval: :timer.seconds(1),
-    global_ttl: :timer.seconds(5),
-    touch_on_read: true
-  ],
-  [name: :my_cache]
-])
+{ConCache, [
+  name: :my_cache,
+  ttl_check_interval: :timer.seconds(1),
+  global_ttl: :timer.seconds(5),
+  touch_on_read: true
+]}
 ```
 
 In addition, you can manually renew item's ttl:
@@ -171,12 +167,10 @@ TTL check __is not__ based on brute force table scan, and should work reasonably
 If needed, you may also pass false to `ttl_check_interval`. This effectively stops `con_cache` from checking the ttl of your items:
 
 ```elixir
-supervisor(ConCache, [
-  [
-    ttl_check_interval: false
-  ],
-  [name: :my_cache]
-])
+{ConCache, [
+  name: :my_cache,
+  ttl_check_interval: false
+]}
 ```
 
 ## Supervision

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -122,8 +122,8 @@ defmodule ConCache do
     with :ok <- validate_ttl(options[:ttl_check_interval], options[:global_ttl]) do
       Supervisor.start_link(
         [
-          Supervisor.Spec.supervisor(ConCache.LockSupervisor, [System.schedulers_online()]),
-          Supervisor.Spec.worker(Owner, [options])
+          {ConCache.LockSupervisor, [System.schedulers_online()]},
+          {Owner, [options]}
         ],
         [strategy: :one_for_all] ++ Keyword.take(sup_opts, [:name])
       )

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -18,7 +18,7 @@ defmodule ConCache do
 
   Example usage:
 
-      ConCache.start_link([], name: :my_cache)
+      ConCache.start_link(name: :my_cache)
       ConCache.put(:my_cache, :foo, 1)
       ConCache.get(:my_cache, :foo)  # 1
 
@@ -37,7 +37,7 @@ defmodule ConCache do
   - In all store operations, you can use `ConCache.Item` struct instead of naked values,
     if you need fine-grained control of item's TTL.
 
-  See `start_link/2` for more details.
+  See `start_link/1` for more details.
   """
 
   alias ConCache.Owner
@@ -62,6 +62,7 @@ defmodule ConCache do
     :ordered_set | :set | :bag | :duplicate_bag | {:name, atom}
 
   @type options :: [
+    {:name, atom} |
     {:global_ttl, non_neg_integer} |
     {:acquire_lock_timeout, pos_integer} |
     {:callback, callback_fun} |
@@ -79,6 +80,7 @@ defmodule ConCache do
   Starts the server and creates an ETS table.
 
   Options:
+    - `{:name, atom} - A name of the cache process.`
     - `{:ttl_check_interval, time_ms | false}` - A check interval for TTL expiry.
       Provide a positive integer for TTL to work, or pass `false` to disable ttl checks.
       See below for more details on inner workings of TTL.
@@ -90,6 +92,7 @@ defmodule ConCache do
     - `{:callback, callback_fun}` - If provided, this function is invoked __after__
       an item is inserted or updated, or __before__ it is deleted.
     - `{:acquire_lock_timeout, timeout_ms}` - The time a client process waits for
+    - `{:ets_options, [ets_option]` – The options for ETS process.
       the lock. Default is 5000.
 
   In addition, following ETS options are supported:
@@ -116,8 +119,8 @@ defmodule ConCache do
   reduce your memory consumption, but could also cause performance penalties.
   Higher values put less pressure on processing, but item expiry is less precise.
   """
-  @spec start_link(options, [name: GenServer.name]) :: Supervisor.on_start
-  def start_link(options, sup_opts \\ []) do
+  @spec start_link(options) :: Supervisor.on_start
+  def start_link(options) do
     options = Keyword.merge(options, [ttl: options[:global_ttl], ttl_check: options[:ttl_check_interval]])
     with :ok <- validate_ttl(options[:ttl_check_interval], options[:global_ttl]) do
       Supervisor.start_link(
@@ -125,7 +128,7 @@ defmodule ConCache do
           {ConCache.LockSupervisor, [System.schedulers_online()]},
           {Owner, [options]}
         ],
-        [strategy: :one_for_all] ++ Keyword.take(sup_opts, [:name])
+        [strategy: :one_for_all] ++ Keyword.take(options, [:name])
       )
     end
   end
@@ -136,12 +139,11 @@ defmodule ConCache do
   defp validate_ttl(_ttl_check_interval, nil), do: raise ArgumentError, "ConCache global_ttl must be supplied"
   defp validate_ttl(_ttl_check_interval, _global_ttl), do: :ok
 
-  @spec child_spec([options]) :: Supervisor.child_spec()
-  def child_spec([]), do: child_spec([[]])
+  @spec child_spec(options) :: Supervisor.child_spec()
   def child_spec(opts) do
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, opts},
+      start: {__MODULE__, :start_link, [opts]},
       type: :supervisor
     }
   end

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -136,6 +136,16 @@ defmodule ConCache do
   defp validate_ttl(_ttl_check_interval, nil), do: raise ArgumentError, "ConCache global_ttl must be supplied"
   defp validate_ttl(_ttl_check_interval, _global_ttl), do: :ok
 
+  @spec child_spec([options]) :: Supervisor.child_spec()
+  def child_spec([]), do: child_spec([[]])
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts},
+      type: :supervisor
+    }
+  end
+
   @doc """
   Returns the ets table managed by the cache.
   """

--- a/lib/con_cache/application.ex
+++ b/lib/con_cache/application.ex
@@ -2,12 +2,11 @@ defmodule ConCache.Application do
   @moduledoc false
 
   use Application
-  import Supervisor.Spec
 
   def start(_, _) do
     Supervisor.start_link(
       [
-        supervisor(Registry, [:unique, ConCache])
+        {Registry, [keys: :unique, name: ConCache]}
       ],
       strategy: :one_for_all
     )

--- a/lib/con_cache/lock.ex
+++ b/lib/con_cache/lock.ex
@@ -15,6 +15,14 @@ defmodule ConCache.Lock do
   @spec start :: {:ok, pid}
   @spec start_link :: {:ok, pid}
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts},
+      type: :worker
+    }
+  end
+
   defstart start(initial_state \\ nil), gen_server_opts: :runtime
   defstart start_link(initial_state \\ nil), gen_server_opts: :runtime do
     initial_state(initial_state || %__MODULE__{})

--- a/lib/con_cache/owner.ex
+++ b/lib/con_cache/owner.ex
@@ -25,6 +25,14 @@ defmodule ConCache.Owner do
     cache
   end
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts},
+      type: :worker
+    }
+  end
+
   defstart start_link(options \\ [])
   defstart start(options \\ []) do
     ets = create_ets(options[:ets_options] || [])

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -37,9 +37,9 @@ defmodule ConCacheTest do
   test "child_spec with args" do
     assert %{
       id: ConCache,
-      start: {ConCache, :start_link, [[global_ttl: 50], [name: :my_cache]]},
+      start: {ConCache, :start_link, [[global_ttl: 50, name: :my_cache]]},
       type: :supervisor
-    } = ConCache.child_spec([[global_ttl: 50], [name: :my_cache]])
+    } = ConCache.child_spec(global_ttl: 50, name: :my_cache)
   end
 
   test "put" do
@@ -370,7 +370,7 @@ defmodule ConCacheTest do
   for name <- [:cache, {:global, :cache}, {:via, :global, :cache2}] do
     test "registration #{inspect name}" do
       name = unquote(Macro.escape(name))
-      {:ok, _} = start_cache([], name: name)
+      {:ok, _} = start_cache([name: name])
       ConCache.put(name, :a, 1)
       assert ConCache.get(name, :a) == 1
     end
@@ -381,7 +381,7 @@ defmodule ConCacheTest do
     assert catch_exit(ConCache.put({:global, :non_existing}, :a, 1)) == :noproc
   end
 
-  defp start_cache(opts \\ [], sup_opts \\ []) do
-    ConCache.start_link(Keyword.merge([ttl_check_interval: false], opts), sup_opts)
+  defp start_cache(opts \\ []) do
+    ConCache.start_link(Keyword.merge([ttl_check_interval: false], opts))
   end
 end

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -26,6 +26,22 @@ defmodule ConCacheTest do
     end
   end
 
+  test "default child_spec" do
+    assert %{
+      id: ConCache,
+      start: {ConCache, :start_link, [[]]},
+      type: :supervisor
+    } = ConCache.child_spec([])
+  end
+
+  test "child_spec with args" do
+    assert %{
+      id: ConCache,
+      start: {ConCache, :start_link, [[global_ttl: 50], [name: :my_cache]]},
+      type: :supervisor
+    } = ConCache.child_spec([[global_ttl: 50], [name: :my_cache]])
+  end
+
   test "put" do
     {:ok, cache} = start_cache()
     assert ConCache.put(cache, :a, 1) == :ok


### PR DESCRIPTION
To follow Elixir 1.5 convention and have simpler setup.

The only issue is that it still requires ttl options to be able to start, but I noticed that you don't want to provide the default value for them (e.g. in #42 discussion). That's why I left it as it is.