### PR TITLE
Fix compiler deprecation messages

### DIFF
--- a/lib/con_cache/lock.ex
+++ b/lib/con_cache/lock.ex
@@ -52,8 +52,6 @@ defmodule ConCache.Lock do
     }
   end
 
-  def handle_info(other, state), do: super(other, state)
-
   @impl GenServer
   def handle_call({:try_lock, id, lock_instance}, {caller_pid, _} = from, state) do
     resource = resource(state, id)

--- a/lib/con_cache/owner.ex
+++ b/lib/con_cache/owner.ex
@@ -66,8 +66,6 @@ defmodule ConCache.Owner do
      |> queue_check}
   end
 
-  def handle_info(unknown_message, state), do: super(unknown_message, state)
-
   defp create_ets(input_options) do
     %{name: name, type: type, options: options} = parse_ets_options(input_options)
     :ets.new(name, [type | options])


### PR DESCRIPTION
Calling super for GenServer callback handle_info/2 is deprecated since Elixir 1.7

The only think that I wasn't sure is should we emit error like [handle_info/2](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/gen_server.ex#L739) in GenServer or silently ignore messages that we don't expect?