### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,27 @@
-/ebin
-/deps
-erl_crash.dump
+# The directory Mix will write compiled artifacts to.
 /_build/
-/doc/
+
+# If you run "mix test --cover", coverage assets end up here.
 /cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+con_cache-*.tar
+
+
+# Temporary files for e.g. tests
+/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
-# v0.14.0
+# Changelog
+
+## v0.14.0 - 2019-08-19
 
 - Requires Elixir 1.7 or newer
 - Added `fetch_or_store/3` and `dirty_fetch_or_store/3`
 
-# v0.13.1
+## v0.13.1 - 2019-02-26
 
 - removed a few compiler warnings
 
-# v0.13.0
+## v0.13.0 - 2018-04-30
 
-## Breaking changes
+### Breaking changes
 
 - Requires Elixir 1.5 or newer
 - The `ConCache.start_link` function takes only one argument. Previously, you needed to pass two keyword lists, which have now been unified in a single kw list. See `ConCache.start_link/1` for details.
@@ -18,82 +20,81 @@
 - If the `:ttl_check_interval` option is set to a positive integer, you also need to pass the `:global_ttl` option.
 - If a cache is configured for expiry, but you want some item to not expire, you need to pass the atom `:infinity` as its TTL value (previously, it was 0).
 
-## Improvements
+### Improvements
 
 - Added `child_spec/1`. A `ConCache` child can now be specified as `{ConCache, [name: :my_cache, ttl_check_interval: false]}`.
 
-# v0.12.1
+## v0.12.1 - 2017-08-03
 
 - Relaxed version requirement for Elixir
 - Proper early exit when the cache doesn't exist
 
-# v0.12.0
+## v0.12.0 - 2017-01-08
 
-## Breaking changes
+### Breaking changes
 
 - Elixir 1.4 is now required.
 - The process started through `ConCache.start_link` is a supervisor (previously it was a worker). Make sure to adapt your supervisor specifications accordingly.
 - `ConCache.start` has been removed.
 
-## Improvements
+### Improvements
 
 - You can now use `bag`, and `duplicate_bag` (thanks to [fcevado](https://github.com/fcevado) for implementing it).
 - Lock processes are now specific for each cache instance (previously they were shared between all of them). Multiple cache instances in the same system will not block each other.
 
-# v0.11.1
+## v0.11.1 - 2016-06-23
 
 - Fix warnings on 1.3.0
 
-# v0.11.0
+## v0.11.0 - 2016-02-15
 
-## Improvements
+### Improvements
 - Support the avoiding prolongation of ttls when updated items through the `:no_update` ttl value in `%ConCache.Item{}`
 
-## Fixes
+### Fixes
 
 - New items inserted with `ConCache.update/3` and `ConCache.dirty_update/3` never expired.
 
+## v0.10.0 - 2016-01-06
 
-# v0.10.0
-
-## Improvements
+### Improvements
 - add `ConCache.size/1`
 
-# v0.9.0
+## v0.9.0 - 2015-09-09
 
-## Fixes
+### Fixes
 - Support for Elixir 1.1
 
-# v0.8.1
+## v0.8.1 - 2015-07-30
 
-## Fixes
+### Fixes
 - Proper unlocking of an item. Previously it was possible that a process keeps the resource locked forever if the lock attempt timed out.
 
-# v0.8.0
+## v0.8.0 - 2015-06-13
 
-## Breaking changes
+### Breaking changes
 - Removed following `ConCache` functions: `size/1`, `memory/1`, `memory_bytes/1`, `get_all/1`, `with_existing/3`
 - Changed `ConCache` update functions: `update/3`, `dirty_update/3`, `update_existing/3` and `dirty_update_existing/3`. The provided lambda now must return either `{:ok, new_value}` or `{:error, reason}`.
 - Changed `ConCache.try_isolated/4` - the function returns `{:ok, result}` or `{:error, reason}`
 - Upgraded to the most recent ExActor
 
-## Fixes
+### Fixes
 - Fixed possible race-conditions on client process crash
 - Fixed mutual exclusion of independent caches
 
-# v0.6.0
+## v0.6.1 - 2014-11-05
 - Elixir v1.0.0
 
-# v0.5.1
+## v0.5.1 - 2014-09-04
 - bugfix: balanced lock wasn't working properly
 
-# v0.5.0
+## v0.5.0 - 2014-09-02
 - upgrade to Elixir v1.0.0-rc1
 
-# v0.4.0
+## v0.4.0 - 2014-08-03
 - upgrade to Elixir v0.15.0
 
-# v0.3.0
+## v0.3.0 - 2014-07-28
 
 With this version, ConCache is turned into a proper application that obeys OTP principles. This required some changes to the way ConCache is used.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # ConCache
 
 [![Build Status](https://travis-ci.org/sasa1977/con_cache.svg?branch=master)](https://travis-ci.org/sasa1977/con_cache)
-[![hex.pm](https://img.shields.io/hexpm/v/con_cache.svg?style=flat-square)](https://hex.pm/packages/con_cache)
-[![hexdocs.pm](https://img.shields.io/badge/docs-latest-green.svg?style=flat-square)](https://hexdocs.pm/con_cache/)
+[![Module Version](https://img.shields.io/hexpm/v/con_cache.svg)](https://hex.pm/packages/con_cache)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/con_cache/)
+[![Total Download](https://img.shields.io/hexpm/dt/con_cache.svg)](https://hex.pm/packages/con_cache)
+[![License](https://img.shields.io/hexpm/l/con_cache.svg)](https://github.com/sasa1977/con_cache/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/sasa1977/con_cache.svg)](https://github.com/sasa1977/con_cache/commits/master)
 
 ConCache (Concurrent Cache) is an ETS based key/value storage with following additional features:
 
@@ -361,3 +364,9 @@ Due to locking and ttl inner workings, multiple copies of each key exist in memo
 ## Status
 
 ConCache has been used in production to manage several thousands of entries served to up to 4000 concurrent clients, on the load of up to 2000 reqs/sec. I don't maintain that project anymore, so I'm not aware of its current status.
+
+## Copyright and License
+
+Copyright (c) 2013 Saša Jurić
+
+Released under the MIT License, which can be found in the repository in [`LICENSE`](https://github.com/sasa1977/con_cache/blob/master/LICENSE).

--- a/mix.exs
+++ b/mix.exs
@@ -3,6 +3,7 @@ Code.ensure_loaded?(Hex) and Hex.start()
 defmodule ConCache.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/sasa1977/con_cache"
   @version "0.14.0"
 
   def project do
@@ -13,37 +14,49 @@ defmodule ConCache.Mixfile do
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      package: [
-        maintainers: ["Saša Jurić"],
-        licenses: ["MIT"],
-        links: %{
-          "GitHub" => "https://github.com/sasa1977/con_cache",
-          "Docs" => "http://hexdocs.pm/con_cache",
-          "Changelog" =>
-            "https://github.com/sasa1977/con_cache/blob/#{@version}/CHANGELOG.md#v#{
-              String.replace(@version, ".", "")
-            }"
-        }
-      ],
-      description:
-        "ETS based key-value storage with support for row-level isolated writes, TTL auto-purge, and modification callbacks.",
-      docs: [
-        extras: ["README.md"],
-        main: "ConCache",
-        source_url: "https://github.com/sasa1977/con_cache/",
-        source_ref: @version
-      ]
+      package: package(),
+      docs: docs()
     ]
   end
 
   def application do
-    [applications: [:logger], mod: {ConCache.Application, []}]
+    [
+      applications: [:logger],
+      mod: {ConCache.Application, []}
+    ]
   end
 
   defp deps do
     [
-      {:ex_doc, "~> 0.19.0", only: :dev},
-      {:dialyxir, "~> 0.5.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
+      {:dialyxir, "~> 0.5.0", only: :dev, runtime: false}
+    ]
+  end
+
+  defp package do
+    [
+      description: """
+        ETS based key-value storage with support for row-level isolated writes,
+        TTL auto-purge, and modification callbacks.
+      """,
+      maintainers: ["Saša Jurić"],
+      licenses: ["MIT"],
+      links: %{
+        "Changelog" => "#{@source_url}/blob/#{@version}/CHANGELOG.md#v#{
+            String.replace(@version, ".", "")
+          }",
+        "GitHub" => @source_url
+      }
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["CHANGELOG.md", "README.md"],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: @version,
+      formatters: ["html"]
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,11 @@
 %{
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm", "6c32a70ed5d452c6650916555b1f96c79af5fc4bf286997f8b15f213de786f73"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm", "000aaeff08919e95e7aea13e4af7b2b9734577b3e6a7c50ee31ee88cab6ec4fb"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
+  "ex_doc": {:hex, :ex_doc, "0.24.0", "2df14354835afaabdf87cb2971ea9485d8a36ff590e4b6c250b4f60c8fdf9143", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "a0f4bcff21ceebea48414e49885d2a3e542200f76a2facf3f8faa54935eeb721"},
   "exactor": {:hex, :exactor, "2.2.3", "a6972f43bb6160afeb73e1d8ab45ba604cd0ac8b5244c557093f6e92ce582786", [:mix], []},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
+  "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
 }

--- a/package.exs
+++ b/package.exs
@@ -1,6 +1,6 @@
 Expm.Package.new(
   name: "con_cache", description: "ets based key/value cache with row level isolated writes and ttl support",
-  version: "0.1", keywords: ["elixir", "ets", "cache"], 
+  version: "0.1", keywords: ["elixir", "ets", "cache"],
   maintainers: [[name: "Sasa Juric", email: "sasa.juric@gmail.com"]],
   repositories: [[github: "sasa1977/con_cache"]]
 )


### PR DESCRIPTION
Besides other changes, this commit ensures the generated HTML doc for
HexDocs.pm will become the main source doc for this Elixir library which
leverage on ExDoc features.

List of changes:
* Update formatter config
* Update gitignore
* Refactor project config
* Output only html doc
* Use common source url
* Set readme as main html page
* Add changelog to html doc
* Fix markdowns and missing dates in changelog
* Code format
* Badges and more badges!
* Add license section

Screenshot:
![Screenshot-20210318223239-2710x1462](https://user-images.githubusercontent.com/134518/111644756-16afcc80-883b-11eb-8e97-3d8ec4ffabb5.png)
