### PR TITLE
Import Bitwise instead of `use`

### DIFF
--- a/lib/con_cache/owner.ex
+++ b/lib/con_cache/owner.ex
@@ -2,7 +2,7 @@ defmodule ConCache.Owner do
   @moduledoc false
 
   use GenServer
-  use Bitwise
+  import Bitwise
 
   defstruct ttl_check: nil,
             current_time: 1,


### PR DESCRIPTION
Resolves the following warning.

```
warning: use Bitwise is deprecated. import Bitwise instead
  lib/con_cache/owner.ex:5: ConCache.Owner
```

@sasa1977 How far back in elixir and erlang are you planning on supporting? I suspect this import wont work for elixir 1.11