### PR TITLE
Bump tool versions to latest OTP 25 and Elixir 1.14

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,2 @@
-erlang 23.1
-elixir 1.11.3-otp-23
-golang 1.15
+erlang 25.1
+elixir 1.14.2-otp-25


### PR DESCRIPTION
* Removes `golang`. Doesn't appear to be used by this project.
* Updates Erlang to 25.1
* Updates Elixir to 1.14.2
