### PR TITLE
Bump actions/cache and actions/checkout to v3

### DIFF
--- a/.github/workflows/con_cache.yaml
+++ b/.github/workflows/con_cache.yaml
@@ -16,7 +16,7 @@ jobs:
         otp: ["25"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1
         with:
@@ -24,7 +24,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
           version-type: strict
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: deps
           key: ${{ matrix.os }}-otp_${{ matrix.otp }}-elixir_${{ matrix.elixir }}-mix_${{ hashFiles('**/mix.lock') }}
@@ -59,7 +59,7 @@ jobs:
             otp: "25"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1
         with:
@@ -68,7 +68,7 @@ jobs:
           version-type: strict
 
       - name: Restore cached deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: deps
           key: ${{ matrix.os }}-otp_${{ matrix.otp }}-elixir_${{ matrix.elixir }}-mix_${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
I used the older deprecated versions. These should stop complaining.