### PR TITLE
Supports decentralized_counters ets option

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ ConCache.start_link(ets_options: [
   :ordered_set,
   {:read_concurrency, true},
   {:write_concurrency, true},
+  {:decentralized_counters, true},
   {:heir, heir_pid}
 ])
 ```

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -67,6 +67,7 @@ defmodule ConCache do
           | {:heir, pid}
           | {:write_concurrency, boolean}
           | {:read_concurrency, boolean}
+          | {:decentralized_counters, boolean}
           | :ordered_set
           | :set
           | :bag
@@ -122,6 +123,7 @@ defmodule ConCache do
     - `:heir`
     - `:write_concurrency`
     - `:read_concurrency`
+    - `:decentralized_counters`
 
   ## Child specification
 

--- a/lib/con_cache/owner.ex
+++ b/lib/con_cache/owner.ex
@@ -78,6 +78,7 @@ defmodule ConCache.Owner do
       {:heir, _} = opt, acc -> append_option(acc, opt)
       {:write_concurrency, _} = opt, acc -> append_option(acc, opt)
       {:read_concurrency, _} = opt, acc -> append_option(acc, opt)
+      {:decentralized_counters, _} = opt, acc -> append_option(acc, opt)
       :ordered_set, acc -> %{acc | type: :ordered_set}
       :set, acc -> %{acc | type: :set}
       :bag, acc -> %{acc | type: :bag}


### PR DESCRIPTION
This PRs adds the support for `decentralized_counts` for ets options. 

More details on the [ets docs](https://www.erlang.org/blog/scalable-ets-counters/).

Any suggestion on the best way to test this?