### PR TITLE
Require value for ttl when using Item as value

### DIFF
--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -2,7 +2,8 @@ defmodule ConCache.Item do
   @moduledoc """
   This struct can be used in place of naked values to set per-item TTL values.
   """
-  defstruct value: nil, ttl: :infinity
+  @enforce_keys [:value, :ttl]
+  defstruct [:value, :ttl]
 
   @type t :: %ConCache.Item{
           value: ConCache.value(),


### PR DESCRIPTION
Resolves https://github.com/sasa1977/con_cache/issues/73

@sasa1977 thanks for considering these changes

I may have gone a little overboard on the README example changes. Let me know if you want me to scale that back :)

When considering addressing the use of the Item struct, it seemed like [this line](https://github.com/sasa1977/con_cache/pull/74/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R151) is conveying the point so I just changed it a bit to make the intention of the example more explicit.

Also, I normally wouldn't test code like this but let me know if you'd prefer to add something.

Finally, if you think this change does make sense, I wonder whether the value should be required as well?