### PR TITLE
Emit telemetry events for hit and miss

### DIFF
--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -354,8 +354,14 @@ defmodule ConCache do
   without any locking, so you can expect it to be fairly fast.
   """
   @spec fetch_or_store(t, key, fetch_or_store_fun) :: {:ok, value} | {:error, any}
-  def fetch_or_store(cache_id, key, fetch_or_store_fun),
-    do: Operations.fetch_or_store(Owner.cache(cache_id), key, fetch_or_store_fun)
+  def fetch_or_store(cache_id, key, fetch_or_store_fun) do
+    cache = Owner.cache(cache_id)
+
+    case Operations.fetch(cache, key) do
+      :error -> Operations.isolated_fetch_or_store(cache, key, fetch_or_store_fun)
+      {:ok, existing} -> {:ok, existing}
+    end
+  end
 
   @doc """
   Dirty equivalent of `fetch_or_store/3`.

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -224,20 +224,10 @@ defmodule ConCache do
   """
   @spec get(t, key) :: value
   def get(cache_id, key) do
-    case fetch(cache_id, key) do
+    case Operations.fetch(Owner.cache(cache_id), key) do
       :error -> nil
       {:ok, value} -> value
     end
-  end
-
-  @doc """
-  Fetches the item from cache.
-
-  Similar to `get/2`, but returns `{:ok, value}` if the item exists, or `:error` if not found.
-  """
-  @spec fetch(t, key) :: {:ok, value} | :error
-  def fetch(cache_id, key) do
-    Operations.fetch(Owner.cache(cache_id), key)
   end
 
   @doc """
@@ -365,8 +355,10 @@ defmodule ConCache do
   """
   @spec fetch_or_store(t, key, fetch_or_store_fun) :: {:ok, value} | {:error, any}
   def fetch_or_store(cache_id, key, fetch_or_store_fun) do
-    case fetch(cache_id, key) do
-      :error -> Operations.isolated_fetch_or_store(Owner.cache(cache_id), key, fetch_or_store_fun)
+    cache = Owner.cache(cache_id)
+
+    case Operations.fetch(cache, key) do
+      :error -> Operations.isolated_fetch_or_store(cache, key, fetch_or_store_fun)
       {:ok, existing} -> {:ok, existing}
     end
   end

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -223,7 +223,12 @@ defmodule ConCache do
   `touch_on_read` option is set while starting the cache.
   """
   @spec get(t, key) :: value
-  def get(cache_id, key), do: Operations.get(Owner.cache(cache_id), key)
+  def get(cache_id, key) do 
+    case Operations.fetch(Owner.cache(cache_id), key) do
+      :error -> nil
+      {:ok, value} -> value
+    end
+  end
 
   @doc """
   Stores the item into the cache.

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -223,7 +223,7 @@ defmodule ConCache do
   `touch_on_read` option is set while starting the cache.
   """
   @spec get(t, key) :: value
-  def get(cache_id, key) do 
+  def get(cache_id, key) do
     case Operations.fetch(Owner.cache(cache_id), key) do
       :error -> nil
       {:ok, value} -> value

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -224,10 +224,20 @@ defmodule ConCache do
   """
   @spec get(t, key) :: value
   def get(cache_id, key) do
-    case Operations.fetch(Owner.cache(cache_id), key) do
+    case fetch(cache_id, key) do
       :error -> nil
       {:ok, value} -> value
     end
+  end
+
+  @doc """
+  Fetches the item from cache.
+
+  Similar to `get/2`, but returns `{:ok, value}` if the item exists, or `:error` if not found.
+  """
+  @spec fetch(t, key) :: {:ok, value} | :error
+  def fetch(cache_id, key) do
+    Operations.fetch(Owner.cache(cache_id), key)
   end
 
   @doc """
@@ -355,10 +365,8 @@ defmodule ConCache do
   """
   @spec fetch_or_store(t, key, fetch_or_store_fun) :: {:ok, value} | {:error, any}
   def fetch_or_store(cache_id, key, fetch_or_store_fun) do
-    cache = Owner.cache(cache_id)
-
-    case Operations.fetch(cache, key) do
-      :error -> Operations.isolated_fetch_or_store(cache, key, fetch_or_store_fun)
+    case fetch(cache_id, key) do
+      :error -> Operations.isolated_fetch_or_store(Owner.cache(cache_id), key, fetch_or_store_fun)
       {:ok, existing} -> {:ok, existing}
     end
   end

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -51,7 +51,8 @@ defmodule ConCache do
     :acquire_lock_timeout,
     :callback,
     :touch_on_read,
-    :lock_pids
+    :lock_pids,
+    :name
   ]
 
   @type t :: pid | atom | {:global, any} | {:via, atom, any}

--- a/lib/con_cache.ex
+++ b/lib/con_cache.ex
@@ -354,14 +354,8 @@ defmodule ConCache do
   without any locking, so you can expect it to be fairly fast.
   """
   @spec fetch_or_store(t, key, fetch_or_store_fun) :: {:ok, value} | {:error, any}
-  def fetch_or_store(cache_id, key, fetch_or_store_fun) do
-    cache = Owner.cache(cache_id)
-
-    case Operations.fetch(cache, key) do
-      :error -> Operations.isolated_fetch_or_store(cache, key, fetch_or_store_fun)
-      {:ok, existing} -> {:ok, existing}
-    end
-  end
+  def fetch_or_store(cache_id, key, fetch_or_store_fun),
+    do: Operations.fetch_or_store(Owner.cache(cache_id), key, fetch_or_store_fun)
 
   @doc """
   Dirty equivalent of `fetch_or_store/3`.

--- a/lib/con_cache/operations.ex
+++ b/lib/con_cache/operations.ex
@@ -220,7 +220,7 @@ defmodule ConCache.Operations do
     end
   end
 
-  def isolated_fetch_or_store(cache, key, fun) do
+  defp isolated_fetch_or_store(cache, key, fun) do
     isolated(cache, key, fn ->
       dirty_fetch_or_store(cache, key, fun)
     end)

--- a/lib/con_cache/operations.ex
+++ b/lib/con_cache/operations.ex
@@ -22,15 +22,18 @@ defmodule ConCache.Operations do
 
   def get(cache, key, opts \\ []) do
     case fetch(cache, key) do
-      {:ok, value} -> 
-        if Keyword.get(opts, :emit_telemetry?, true) do 
+      {:ok, value} ->
+        if Keyword.get(opts, :emit_telemetry?, true) do
           emit(cache, telemetry_hit())
         end
+
         value
-      :error -> 
-        if Keyword.get(opts, :emit_telemetry?, true) do 
+
+      :error ->
+        if Keyword.get(opts, :emit_telemetry?, true) do
           emit(cache, telemetry_miss())
         end
+
         nil
     end
   end
@@ -186,8 +189,10 @@ defmodule ConCache.Operations do
   def get_or_store(cache, key, fun) do
     if valid_ets_type?(cache) do
       case get(cache, key, emit_telemetry?: false) do
-        nil -> isolated_get_or_store(cache, key, fun)
-        value -> 
+        nil ->
+          isolated_get_or_store(cache, key, fun)
+
+        value ->
           emit(cache, telemetry_hit())
           value
       end

--- a/lib/con_cache/operations.ex
+++ b/lib/con_cache/operations.ex
@@ -220,7 +220,7 @@ defmodule ConCache.Operations do
     end
   end
 
-  defp isolated_fetch_or_store(cache, key, fun) do
+  def isolated_fetch_or_store(cache, key, fun) do
     isolated(cache, key, fn ->
       dirty_fetch_or_store(cache, key, fun)
     end)

--- a/lib/con_cache/owner.ex
+++ b/lib/con_cache/owner.ex
@@ -43,7 +43,8 @@ defmodule ConCache.Owner do
       acquire_lock_timeout: options[:acquire_lock_timeout] || 5000,
       callback: options[:callback],
       touch_on_read: options[:touch_on_read] || false,
-      lock_pids: List.to_tuple(ConCache.LockSupervisor.lock_pids(parent_process()))
+      lock_pids: List.to_tuple(ConCache.LockSupervisor.lock_pids(parent_process())),
+      name: options[:name]
     }
 
     {:ok, _} = Registry.register(ConCache, {parent_process(), __MODULE__}, cache)

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule ConCache.Mixfile do
 
   def application do
     [
-      applications: [:logger],
+      applications: [:logger, :telemetry],
       mod: {ConCache.Application, []}
     ]
   end
@@ -26,7 +26,8 @@ defmodule ConCache.Mixfile do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:dialyxir, "~> 1.0", only: :dev, runtime: false}
+      {:dialyxir, "~> 1.0", only: :dev, runtime: false},
+      {:telemetry, "~> 1.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -7,4 +7,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
 }

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -475,9 +475,15 @@ defmodule ConCacheTest do
     hit = ConCache.Operations.telemetry_hit()
     miss = ConCache.Operations.telemetry_miss()
 
-    :telemetry.attach_many("test", [
-      hit, miss
-    ], &TestTelemetryHandler.handle_event/4, nil)
+    :telemetry.attach_many(
+      "test",
+      [
+        hit,
+        miss
+      ],
+      &TestTelemetryHandler.handle_event/4,
+      nil
+    )
 
     ConCache.get(cache, :key)
     assert_receive {:telemetry_handled, ^miss, %{cache: %{owner_pid: ^cache}}}
@@ -494,9 +500,15 @@ defmodule ConCacheTest do
     hit = ConCache.Operations.telemetry_hit()
     miss = ConCache.Operations.telemetry_miss()
 
-    :telemetry.attach_many("test", [
-      hit, miss
-    ], &TestTelemetryHandler.handle_event/4, nil)
+    :telemetry.attach_many(
+      "test",
+      [
+        hit,
+        miss
+      ],
+      &TestTelemetryHandler.handle_event/4,
+      nil
+    )
 
     ConCache.get_or_store(cache, :key, fn -> :value end)
     assert_receive {:telemetry_handled, ^miss, %{cache: %{owner_pid: ^cache}}}
@@ -512,9 +524,15 @@ defmodule ConCacheTest do
     hit = ConCache.Operations.telemetry_hit()
     miss = ConCache.Operations.telemetry_miss()
 
-    :telemetry.attach_many("test", [
-      hit, miss
-    ], &TestTelemetryHandler.handle_event/4, nil)
+    :telemetry.attach_many(
+      "test",
+      [
+        hit,
+        miss
+      ],
+      &TestTelemetryHandler.handle_event/4,
+      nil
+    )
 
     ConCache.put(cache, :key, fn -> :value end)
     ConCache.get_or_store(cache, :key, fn -> :value end)

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -283,13 +283,6 @@ defmodule ConCacheTest do
     assert ConCache.get(cache, :b) == 6
   end
 
-  test "fetch" do
-    {:ok, cache} = start_cache()
-    assert ConCache.dirty_put(cache, :a, 1) == :ok
-    assert ConCache.fetch(cache, :a) == {:ok, 1}
-    assert ConCache.fetch(cache, :b) == :error
-  end
-
   test "ets_options" do
     {:ok, cache} = start_cache(ets_options: [:named_table, name: :test_name])
     assert :ets.info(ConCache.ets(cache), :named_table) == true

--- a/test/con_cache_test.exs
+++ b/test/con_cache_test.exs
@@ -283,6 +283,13 @@ defmodule ConCacheTest do
     assert ConCache.get(cache, :b) == 6
   end
 
+  test "fetch" do
+    {:ok, cache} = start_cache()
+    assert ConCache.dirty_put(cache, :a, 1) == :ok
+    assert ConCache.fetch(cache, :a) == {:ok, 1}
+    assert ConCache.fetch(cache, :b) == :error
+  end
+
   test "ets_options" do
     {:ok, cache} = start_cache(ets_options: [:named_table, name: :test_name])
     assert :ets.info(ConCache.ets(cache), :named_table) == true


### PR DESCRIPTION
Tentative first pass on #75 

Since `get` might be effectively called twice by `get_or_store`, we need a way to suppress emitting telemetry events on plain `get`.

I'll add documentation upon implementation approval.